### PR TITLE
Bugfix - fix keypress chain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ function onKeyDown(
         case KEY_BACKSPACE:
             return onBackspace(...args);
         default:
-            return undefined;
+            return next();
     }
 }
 


### PR DESCRIPTION
Returning undefined breaks chaining for any other plugins defining keyboard actions, call next to move on to next plugin